### PR TITLE
implement date arguments for weekly-report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.0.3]
 
+- implement date arguments for weekly-report #5
 
 [0.0.3]: https://github.com/eventum/cli/compare/0.0.2...master
 

--- a/src/Command/AddTimeEntryCommand.php
+++ b/src/Command/AddTimeEntryCommand.php
@@ -78,8 +78,8 @@ EOT
     }
 
     /**
-     * @return int
      * @throws InvalidArgumentException
+     * @return int
      */
     private function getCategory($issue_id)
     {

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -120,8 +120,8 @@ class Command extends BaseCommand
      *
      * @param string $url
      * @throws InvalidArgumentException
-     * @return array
      * @throws RuntimeException
+     * @return array
      */
     private function askAuthentication($url, $retry = 3)
     {

--- a/src/Command/SelfUpdateManifestCommand.php
+++ b/src/Command/SelfUpdateManifestCommand.php
@@ -79,8 +79,8 @@ EOT
      *
      * @param string $pharFile
      * @param $pharFile
-     * @return string
      * @throws RuntimeException
+     * @return string
      */
     private function getPharFileVersion($pharFile)
     {

--- a/src/Command/WeeklyReportCommand.php
+++ b/src/Command/WeeklyReportCommand.php
@@ -52,31 +52,18 @@ class WeeklyReportCommand extends Command
             ->setHelp(
                 <<<EOT
 
-<info>%command.full_name% [<week>] [--separate-closed]</info>
-<info>%command.full_name% [<start>] [<end>] [--separate-closed]</info>
+<info>%command.full_name% [<start_date>] [<end_date>] [--separate-closed]</info>
 
-Fetches the weekly report. Week is specified as an integer with 0 representing
-the current week, -1 the previous week and so on. If the week is omitted it 
-defaults to the current week. Alternately, a date range can be set. Dates 
-should be in the format 'YYYY-MM-DD'.
+Shows the weekly report.
+
+Dates should be in the format 'YYYY-MM-DD'.
 EOT
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $start = (string)$input->getArgument('start');
-        $end = (string)$input->getArgument('end');
-        $options = array(
-            'separate_closed' => $input->getOption('separate-closed'),
-        );
-
-        // take current week
-        $start = new DateTime('Last Monday');
-        $end = new DateTime('Next Monday');
-
-        $prj_id = $this->getProjectId();
-        $data = $this->getClient()->getWeeklyReportData($prj_id, $start, $end, $options);
+        $data = $this->getWeeklyReportData();
 
         $group_name = isset($data['group_name']) ? "[{$data['group_name']}]" : '';
         $output->writeln(
@@ -121,5 +108,27 @@ EOT
         $output->writeln("Login Time Spent:     $time_spent");
 
         $output->writeln("Total Time Spent:     {$data['total_time']}");
+    }
+
+    private function getWeeklyReportData()
+    {
+        list($start, $end) = $this->getDateRange();
+        $prj_id = $this->getProjectId();
+        $options = array(
+            'separate_closed' => $this->input->getOption('separate-closed'),
+        );
+
+        return $this->getClient()->getWeeklyReportData($prj_id, $start, $end, $options);
+    }
+
+    private function getDateRange()
+    {
+        $start = $this->input->getArgument('start') ?: 'Last Monday';
+        $end = $this->input->getArgument('end') ?: 'Next Monday';
+
+        return array(
+            new DateTime($start),
+            new DateTime($end),
+        );
     }
 }

--- a/src/Command/WeeklyReportCommand.php
+++ b/src/Command/WeeklyReportCommand.php
@@ -74,7 +74,6 @@ EOT
         // take current week
         $start = new DateTime('Last Monday');
         $end = new DateTime('Next Monday');
-        // TODO: handle parameters and week option
 
         $prj_id = $this->getProjectId();
         $data = $this->getClient()->getWeeklyReportData($prj_id, $start, $end, $options);


### PR DESCRIPTION
currently usage was taken from old cli app:

```
➔ ./eventum.php wr --help
Help:

  ./eventum.php weekly-report [<week>] [--separate-closed]
  ./eventum.php weekly-report [<start>] [<end>] [--separate-closed]

  Fetches the weekly report. Week is specified as an integer with 0 representing
  the current week, -1 the previous week and so on. If the week is omitted it
  defaults to the current week. Alternately, a date range can be set. Dates
  should be in the format 'YYYY-MM-DD'.

```

it's not very intuitive and not easy to process such commandline arguments.

so none of that is implemented: [src/Command/WeeklyReportCommand.php:74-77](https://github.com/eventum/cli/blob/f31f494ffddb649bd7f2a28950b45bb3f72c1667/src/Command/WeeklyReportCommand.php#L74-L77)

should propose interface using arguments or options.