### PR TITLE
namespace commands grouping them logically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@ When writing entries, refer to [Keep a CHANGELOG](http://keepachangelog.com/) fo
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.4]
+## [0.1.0]
 
-- file upload: test that input file is accessible #6
+- file upload: test that input file is accessible, #6
+- namespace commands grouping them logically, #7
 
-[0.0.4]: https://github.com/eventum/cli/compare/0.0.3...master
+[0.1.0]: https://github.com/eventum/cli/compare/0.0.3...master
 
 ## [0.0.3] - 2017-10-04
 
-- implement date arguments for weekly-report #5
+- implement date arguments for weekly-report, #5
 - add `close` command to close issues, #4
 
 [0.0.3]: https://github.com/eventum/cli/compare/0.0.2...0.0.3

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ Elan Ruusamäe Weekly Report 2015.04.27 - 2015.05.03
 
 Available commands:
 
-| Command | |
-| ------------- | ------------- |
-| **add-attachment** | Add attachment to issue  |
-| **close** | Marks an issue as closed |
-| **open-issues** | List open issues |
-| **set-status**, **ss** | Set Issue status |
-| **view-issue** | Display Issue details |
-| **weekly-report**, **wr**  | Show weekly reports |
+| Command               |                                       |
+| --------------------- | ------------------------------------- |
+| **attachment:upload** | Upload attachment to an issue         |
+| **issue:close**       | Marks an issue as closed              |
+| **issue:list**        | List open issues                      |
+| **issue:status**      | Set Issue status                      |
+| **issue:view**        | Display Issue details                 |
+| **report:weekly**     | Show weekly reports                   |
+| **time:spend**        | Add time-tracking entry to an issue   |

--- a/src/Application.php
+++ b/src/Application.php
@@ -52,7 +52,7 @@ class Application extends BaseApplication
         $commands[] = new Command\ViewIssueCommand();
         $commands[] = new Command\WeeklyReportCommand();
         $commands[] = new Command\CreateIssueCommand();
-        $commands[] = new Command\AddAttachmentCommand();
+        $commands[] = new Command\UploadAttachmentCommand();
         $commands[] = new Command\DumpMethodsCommand();
         $commands[] = new Command\ConfigCommand();
         $commands[] = new Command\AddTimeEntryCommand();

--- a/src/Application.php
+++ b/src/Application.php
@@ -60,7 +60,7 @@ class Application extends BaseApplication
         $commands[] = new Command\CloseIssueCommand();
 
         if (strpos(__FILE__, 'phar:') === 0) {
-            $commands[] = new Command\SelfUpdateCommand('self-update');
+            $commands[] = new Command\SelfUpdateCommand(Command\SelfUpdateCommand::COMMAND_NAME);
         }
 
         if (class_exists('Eventum\Console\Command\SelfUpdateManifestCommand')) {

--- a/src/Command/AddAttachmentCommand.php
+++ b/src/Command/AddAttachmentCommand.php
@@ -23,10 +23,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AddAttachmentCommand extends Command
 {
+    const COMMAND_NAME = 'add-attachment';
+
     protected function configure()
     {
         $this
-            ->setName('add-attachment')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('Add attachment to issue')
             ->addArgument(
                 'issue_id',
@@ -114,8 +116,8 @@ EOT
 
     /**
      * @param string $fileName
-     * @return string
      * @throws RuntimeException
+     * @return string
      */
     private function getFileContents($fileName)
     {
@@ -133,6 +135,7 @@ EOT
         if ($contents === false) {
             throw new RuntimeException("Unable to read $fileName");
         }
+
         return $contents;
     }
 

--- a/src/Command/AddTimeEntryCommand.php
+++ b/src/Command/AddTimeEntryCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AddTimeEntryCommand extends Command
 {
-    const COMMAND_NAME = 'add-time';
+    const COMMAND_NAME = 'timetracking:add';
 
     /**
      * @var RemoteApi|Eventum_RPC
@@ -34,6 +34,7 @@ class AddTimeEntryCommand extends Command
     {
         $this
             ->setName(self::COMMAND_NAME)
+            ->setAliases(array('add-time'))
             ->setDescription('Add time-tracking entry to an issue')
             ->addArgument(
                 'issue_id',

--- a/src/Command/AddTimeEntryCommand.php
+++ b/src/Command/AddTimeEntryCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AddTimeEntryCommand extends Command
 {
-    const COMMAND_NAME = 'timetracking:add';
+    const COMMAND_NAME = 'time:spend';
 
     /**
      * @var RemoteApi|Eventum_RPC

--- a/src/Command/AddTimeEntryCommand.php
+++ b/src/Command/AddTimeEntryCommand.php
@@ -23,6 +23,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AddTimeEntryCommand extends Command
 {
+    const COMMAND_NAME = 'add-time';
+
     /**
      * @var RemoteApi|Eventum_RPC
      */
@@ -31,7 +33,7 @@ class AddTimeEntryCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('add-time')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('Add time-tracking entry to an issue')
             ->addArgument(
                 'issue_id',

--- a/src/Command/CloseIssueCommand.php
+++ b/src/Command/CloseIssueCommand.php
@@ -20,12 +20,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CloseIssueCommand extends Command
 {
-    const COMMAND_NAME = 'close';
+    const COMMAND_NAME = 'issue:close';
 
     protected function configure()
     {
         $this
             ->setName(self::COMMAND_NAME)
+            ->setAliases(array('close'))
             ->setDescription('Marks an issue as closed')
             ->addArgument(
                 'issue_id',

--- a/src/Command/CloseIssueCommand.php
+++ b/src/Command/CloseIssueCommand.php
@@ -20,10 +20,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CloseIssueCommand extends Command
 {
+    const COMMAND_NAME = 'close';
+
     protected function configure()
     {
         $this
-            ->setName('close')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('Marks an issue as closed')
             ->addArgument(
                 'issue_id',

--- a/src/Command/ConfigCommand.php
+++ b/src/Command/ConfigCommand.php
@@ -19,10 +19,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ConfigCommand extends Command
 {
+    const COMMAND_NAME = 'config';
+
     protected function configure()
     {
         $this
-            ->setName('config')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('Set config options')
             ->addOption(
                 'list',

--- a/src/Command/CreateIssueCommand.php
+++ b/src/Command/CreateIssueCommand.php
@@ -20,10 +20,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateIssueCommand extends Command
 {
+    const COMMAND_NAME = 'create-issue';
+
     protected function configure()
     {
         $this
-            ->setName('create-issue')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('Create issue')
             ->addOption(
                 'summary',

--- a/src/Command/CreateIssueCommand.php
+++ b/src/Command/CreateIssueCommand.php
@@ -20,13 +20,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateIssueCommand extends Command
 {
-    const COMMAND_NAME = 'create-issue';
+    const COMMAND_NAME = 'issue:close';
 
     protected function configure()
     {
         $this
             ->setName(self::COMMAND_NAME)
             ->setDescription('Create issue')
+            ->setAliases(array('create-issue'))
             ->addOption(
                 'summary',
                 's',

--- a/src/Command/DumpMethodsCommand.php
+++ b/src/Command/DumpMethodsCommand.php
@@ -23,6 +23,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DumpMethodsCommand extends Command
 {
+    const COMMAND_NAME = 'dump-methods';
+
     /**
      * @var RemoteApi|Eventum_RPC
      */
@@ -31,7 +33,7 @@ class DumpMethodsCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('dump-methods')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('Dump available XMLRPC methods from Eventum')
             ->addArgument(
                 'method',

--- a/src/Command/DumpMethodsCommand.php
+++ b/src/Command/DumpMethodsCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DumpMethodsCommand extends Command
 {
-    const COMMAND_NAME = 'dump-methods';
+    const COMMAND_NAME = 'system:dump-methods';
 
     /**
      * @var RemoteApi|Eventum_RPC
@@ -34,6 +34,7 @@ class DumpMethodsCommand extends Command
     {
         $this
             ->setName(self::COMMAND_NAME)
+            ->setAliases(array('dump-methods'))
             ->setDescription('Dump available XMLRPC methods from Eventum')
             ->addArgument(
                 'method',

--- a/src/Command/ListIssuesCommand.php
+++ b/src/Command/ListIssuesCommand.php
@@ -20,10 +20,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ListIssuesCommand extends Command
 {
+    const COMMAND_NAME = 'open-issues';
+
     protected function configure()
     {
         $this
-            ->setName('open-issues')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('List open issues')
             ->addOption(
                 'status',

--- a/src/Command/ListIssuesCommand.php
+++ b/src/Command/ListIssuesCommand.php
@@ -20,12 +20,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ListIssuesCommand extends Command
 {
-    const COMMAND_NAME = 'open-issues';
+    const COMMAND_NAME = 'issue:list';
 
     protected function configure()
     {
         $this
             ->setName(self::COMMAND_NAME)
+            ->setAliases(array('open-issues'))
             ->setDescription('List open issues')
             ->addOption(
                 'status',

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -21,6 +21,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SelfUpdateCommand extends Amend\Command
 {
+    const COMMAND_NAME = 'self-update';
+
     const MANIFEST_FILE = 'https://eventum.github.io/cli/manifest.json';
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Command/SelfUpdateManifestCommand.php
+++ b/src/Command/SelfUpdateManifestCommand.php
@@ -22,12 +22,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SelfUpdateManifestCommand extends Command
 {
+    const COMMAND_NAME = 'create-manifest';
+
     const DIST_URL = 'https://raw.githubusercontent.com/eventum/cli/dist/eventum.phar';
 
     protected function configure()
     {
         $this
-            ->setName('create-manifest')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('Creates manifest.json for self-update command')
             ->addArgument(
                 'phar-file',

--- a/src/Command/SelfUpdateManifestCommand.php
+++ b/src/Command/SelfUpdateManifestCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SelfUpdateManifestCommand extends Command
 {
-    const COMMAND_NAME = 'create-manifest';
+    const COMMAND_NAME = 'system:create-manifest';
 
     const DIST_URL = 'https://raw.githubusercontent.com/eventum/cli/dist/eventum.phar';
 
@@ -30,6 +30,7 @@ class SelfUpdateManifestCommand extends Command
     {
         $this
             ->setName(self::COMMAND_NAME)
+            ->setAliases(array('create-manifest'))
             ->setDescription('Creates manifest.json for self-update command')
             ->addArgument(
                 'phar-file',

--- a/src/Command/SetIssueStatusCommand.php
+++ b/src/Command/SetIssueStatusCommand.php
@@ -19,10 +19,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SetIssueStatusCommand extends Command
 {
+    const COMMAND_NAME = 'set-status';
+
     protected function configure()
     {
         $this
-            ->setName('set-status')
+            ->setName(self::COMMAND_NAME)
             ->setAliases(array('ss'))
             ->setDescription('Set Issue status')
             ->addArgument(

--- a/src/Command/SetIssueStatusCommand.php
+++ b/src/Command/SetIssueStatusCommand.php
@@ -19,13 +19,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SetIssueStatusCommand extends Command
 {
-    const COMMAND_NAME = 'set-status';
+    const COMMAND_NAME = 'issue:status';
 
     protected function configure()
     {
         $this
             ->setName(self::COMMAND_NAME)
-            ->setAliases(array('ss'))
+            ->setAliases(array('ss', 'set-status'))
             ->setDescription('Set Issue status')
             ->addArgument(
                 'issue_id',

--- a/src/Command/UploadAttachmentCommand.php
+++ b/src/Command/UploadAttachmentCommand.php
@@ -21,15 +21,16 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class AddAttachmentCommand extends Command
+class UploadAttachmentCommand extends Command
 {
-    const COMMAND_NAME = 'add-attachment';
+    const COMMAND_NAME = 'attachment:upload';
 
     protected function configure()
     {
         $this
             ->setName(self::COMMAND_NAME)
-            ->setDescription('Add attachment to issue')
+            ->setAliases(array('add-attachment'))
+            ->setDescription('Upload attachment to an issue')
             ->addArgument(
                 'issue_id',
                 InputArgument::REQUIRED,

--- a/src/Command/ViewIssueCommand.php
+++ b/src/Command/ViewIssueCommand.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ViewIssueCommand extends Command
 {
-    const COMMAND_NAME = 'view-issue';
+    const COMMAND_NAME = 'issue:view';
 
     /**
      * @var RemoteApi|Eventum_RPC
@@ -35,6 +35,7 @@ class ViewIssueCommand extends Command
     {
         $this
             ->setName(self::COMMAND_NAME)
+            ->setAliases(array('view-issue'))
             ->setDescription('Display Issue details')
             ->addArgument(
                 'issue',

--- a/src/Command/ViewIssueCommand.php
+++ b/src/Command/ViewIssueCommand.php
@@ -24,6 +24,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ViewIssueCommand extends Command
 {
+    const COMMAND_NAME = 'view-issue';
+
     /**
      * @var RemoteApi|Eventum_RPC
      */
@@ -32,7 +34,7 @@ class ViewIssueCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('view-issue')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('Display Issue details')
             ->addArgument(
                 'issue',

--- a/src/Command/WeeklyReportCommand.php
+++ b/src/Command/WeeklyReportCommand.php
@@ -21,10 +21,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WeeklyReportCommand extends Command
 {
+    const COMMAND_NAME = 'weekly-report';
+
     protected function configure()
     {
         $this
-            ->setName('weekly-report')
+            ->setName(self::COMMAND_NAME)
             ->setAliases(array('wr'))
             ->setDescription('Show weekly reports')
             ->addArgument(

--- a/src/Command/WeeklyReportCommand.php
+++ b/src/Command/WeeklyReportCommand.php
@@ -21,13 +21,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WeeklyReportCommand extends Command
 {
-    const COMMAND_NAME = 'weekly-report';
+    const COMMAND_NAME = 'report:weekly';
 
     protected function configure()
     {
         $this
             ->setName(self::COMMAND_NAME)
-            ->setAliases(array('wr'))
+            ->setAliases(array('wr', 'weekly-report'))
             ->setDescription('Show weekly reports')
             ->addArgument(
                 'start',

--- a/tests/UploadTest.php
+++ b/tests/UploadTest.php
@@ -14,7 +14,7 @@
 namespace Eventum\Console\Test;
 
 use Eventum\Console\Application;
-use Eventum\Console\Command\AddAttachmentCommand;
+use Eventum\Console\Command\UploadAttachmentCommand;
 use Eventum_RPC_Exception;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
@@ -31,9 +31,9 @@ class UploadTest extends TestCase
     public function setUp()
     {
         $application = new Application();
-        $application->add(new AddAttachmentCommand());
+        $application->add(new UploadAttachmentCommand());
 
-        $this->command = $application->find(AddAttachmentCommand::COMMAND_NAME);
+        $this->command = $application->find(UploadAttachmentCommand::COMMAND_NAME);
         $this->tester = new CommandTester($this->command);
     }
 

--- a/tests/UploadTest.php
+++ b/tests/UploadTest.php
@@ -33,7 +33,7 @@ class UploadTest extends TestCase
         $application = new Application();
         $application->add(new AddAttachmentCommand());
 
-        $this->command = $application->find('add-attachment');
+        $this->command = $application->find(AddAttachmentCommand::COMMAND_NAME);
         $this->tester = new CommandTester($this->command);
     }
 
@@ -51,7 +51,7 @@ class UploadTest extends TestCase
 
     public function testUploadEmptyFile()
     {
-        $file = tempnam(sys_get_temp_dir(), "testfile");
+        $file = tempnam(sys_get_temp_dir(), 'testfile');
         $input = array('issue_id' => '1', 'file' => $file);
 
         try {
@@ -66,7 +66,7 @@ class UploadTest extends TestCase
 
     public function testUploadNofile()
     {
-        $input = array('issue_id' => '1', 'file' => "/proc/nosuch-file-there-ever");
+        $input = array('issue_id' => '1', 'file' => '/proc/nosuch-file-there-ever');
 
         try {
             $this->tester->execute(


### PR DESCRIPTION
The output shows previous aliases (still kept around):

```
$ ./eventum.php list
...
Available commands:
  add-attachment          Upload attachment to an issue
  add-time                Add time-tracking entry to an issue
  close                   Marks an issue as closed
  config                  Set config options
  create-issue            Create issue
  create-manifest         Creates manifest.json for self-update command
  dump-methods            Dump available XMLRPC methods from Eventum
  help                    Displays help for a command
  list                    Lists commands
  open-issues             List open issues
  set-status              Set Issue status
  ss                      Set Issue status
  view-issue              Display Issue details
  weekly-report           Show weekly reports
  wr                      Show weekly reports
```

and actual new namespaced commands:
```
 attachment
  attachment:upload       Upload attachment to an issue
 issue
  issue:close             Marks an issue as closed
  issue:list              List open issues
  issue:status            Set Issue status
  issue:view              Display Issue details
 report
  report:weekly           Show weekly reports
 system
  system:create-manifest  Creates manifest.json for self-update command
  system:dump-methods     Dump available XMLRPC methods from Eventum
 timetracking
  timetracking:add        Add time-tracking entry to an issue
```