### PR TITLE
update eventum/rpc to 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	"require": {
 		"bit3/php-callback-filter-iterator-polyfill": "~1.2",
 		"dnoegel/php-xdg-base-dir": "~0.1",
-		"eventum/rpc": "^4.1.1",
+		"eventum/rpc": "^4.2",
 		"ext-fileinfo": "*",
 		"ext-json": "*",
 		"kherge/amend": "^3.0.0",

--- a/src/Command/AddTimeEntryCommand.php
+++ b/src/Command/AddTimeEntryCommand.php
@@ -13,8 +13,6 @@
 
 namespace Eventum\Console\Command;
 
-use Eventum\RPC\RemoteApi;
-use Eventum_RPC;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,11 +22,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class AddTimeEntryCommand extends Command
 {
     const COMMAND_NAME = 'time:spend';
-
-    /**
-     * @var RemoteApi|Eventum_RPC
-     */
-    private $client;
 
     protected function configure()
     {

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -17,8 +17,8 @@ use Eventum\Console\AuthHelper;
 use Eventum\Console\Config;
 use Eventum\Console\IO;
 use Eventum\Console\Util;
-use Eventum_RPC;
-use Eventum_RPC_Exception;
+use Eventum\RPC\EventumXmlRpcClient;
+use Eventum\RPC\XmlRpcException;
 use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command as BaseCommand;
@@ -63,9 +63,9 @@ class Command extends BaseCommand
     protected $config;
 
     /**
-     * @var Eventum_RPC
+     * @var EventumXmlRpcClient
      */
-    private $client;
+    protected $client;
 
     /**
      * Initializes the command just after the input has been validated.
@@ -99,13 +99,13 @@ class Command extends BaseCommand
     }
 
     /**
-     * @return Eventum_RPC
+     * @return EventumXmlRpcClient
      */
     protected function getClient()
     {
         if (!$this->client) {
             $url = $this->getUrl();
-            $this->client = new Eventum_RPC($url);
+            $this->client = new EventumXmlRpcClient($url);
             $this->client->addUserAgent($this->getUserAgent());
 
             // set debug if verbosity debug
@@ -154,7 +154,7 @@ class Command extends BaseCommand
                 $this->storeAuth($url, $storeAuth);
 
                 return $auth;
-            } catch (Eventum_RPC_Exception $e) {
+            } catch (XmlRpcException $e) {
                 $this->output->writeln("<error>ERROR: {$e->getMessage()}</error>");
             }
             $this->output->writeln('');

--- a/src/Command/DumpMethodsCommand.php
+++ b/src/Command/DumpMethodsCommand.php
@@ -18,7 +18,6 @@ use CallbackFilterIterator;
 use Eventum\Console\Formatter\AnnotateFormatter;
 use Eventum\Console\Formatter\FormatterInterface;
 use Eventum\Console\Formatter\PhpdocFormatter;
-use Eventum_RPC;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,11 +30,6 @@ class DumpMethodsCommand extends Command
 
     const FORMAT_PHPDOC = 'phpdoc';
     const FORMAT_ANNOTATE = 'annotate';
-
-    /**
-     * @var Eventum_RPC
-     */
-    private $client;
 
     protected function configure()
     {

--- a/src/Command/UploadAttachmentCommand.php
+++ b/src/Command/UploadAttachmentCommand.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Console\Command;
 
-use Eventum_RPC_Exception;
+use Eventum\RPC\XmlRpcException;
 use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -90,9 +90,9 @@ EOT
         $binary = $client->encodeBinary($contents);
         try {
             $res = $client->addFile($issue_id, $filename, $mimetype, $binary, $file_description, $internal_only);
-        } catch (Eventum_RPC_Exception $e) {
+        } catch (XmlRpcException $e) {
             if ($e->getMessage() === 'XML error: Invalid document end at line 1') {
-                $this->checkFilesize(strlen($contents));
+                $this->checkFileSize(strlen($contents));
             }
             throw $e;
         }
@@ -158,7 +158,7 @@ EOT
      * @param int $fileSize
      * @throws InvalidArgumentException
      */
-    private function checkFilesize($fileSize)
+    private function checkFileSize($fileSize)
     {
         $max = $this->getMaxFileSize();
         if ($fileSize <= $max) {
@@ -166,8 +166,8 @@ EOT
         }
 
         $max = $this->util->formatMemory($max, 2);
-        $fileSize = $this->util->formatMemory($fileSize, 2);
-        throw new InvalidArgumentException("Uploaded file too big: $fileSize, max filesize $max");
+        $printable = $this->util->formatMemory($fileSize, 2);
+        throw new InvalidArgumentException("Uploaded file too big: $printable, max filesize $max");
     }
 
     /**

--- a/src/Command/ViewIssueCommand.php
+++ b/src/Command/ViewIssueCommand.php
@@ -13,9 +13,7 @@
 
 namespace Eventum\Console\Command;
 
-use Eventum\RPC\RemoteApi;
-use Eventum_RPC;
-use Eventum_RPC_Exception;
+use Eventum\RPC\XmlRpcException;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -25,11 +23,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ViewIssueCommand extends Command
 {
     const COMMAND_NAME = 'issue:view';
-
-    /**
-     * @var RemoteApi|Eventum_RPC
-     */
-    private $client;
 
     protected function configure()
     {
@@ -125,8 +118,8 @@ EOT
     private function showAttachments($issue_id)
     {
         try {
-            $filelist = $this->client->getFileList($issue_id);
-        } catch (Eventum_RPC_Exception $e) {
+            $fileList = $this->client->getFileList($issue_id);
+        } catch (XmlRpcException $e) {
             // may throw "No files could be found"
             return;
         }
@@ -135,7 +128,7 @@ EOT
         $table->setHeaders(array('Attachments'));
 
         $i = 1;
-        foreach ($filelist as $attachment) {
+        foreach ($fileList as $attachment) {
             if ($i > 1) {
                 $table->addRow(new TableSeparator());
             }


### PR DESCRIPTION
- also removes `$client` property being private and thus possibly misused
- eventum/rpc 4.2 includes method descriptions as `@method` annotations.